### PR TITLE
Local player ssl http get

### DIFF
--- a/concierge-app/src/main/java/net/wasdev/gameon/concierge/ConciergeAuthFilter.java
+++ b/concierge-app/src/main/java/net/wasdev/gameon/concierge/ConciergeAuthFilter.java
@@ -232,7 +232,9 @@ public class ConciergeAuthFilter implements Filter{
 		String hmac = request.getParameter(Params.apikey.name());
 		String apikey = digest(queryString,sharedSecret);
 		
-		System.out.println("comparing "+hmac+" TO "+apikey);
+		if(!apikey.equals(hmac))
+		  System.out.println("Hmac mismatch:\n Recieved:   "+hmac+"\n"+
+		                     " Calculated: "+apikey);
 		
 		//store the apiKey for the replay check
 		ctx.apiKey = apikey;


### PR DESCRIPTION
This change depends on the change to the root project that adds the env var that we can use in the player client in the concierge to ignore the host names during local execution of gameon. 

SSL is still being used, and validated as trusted, just the hostname restriction has been relaxed.